### PR TITLE
fix: GHA Docs Generation - Checkout repo step

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -11,6 +11,8 @@ jobs:
         working-directory: ./cdp-agentkit-core
 
     steps:
+      - uses: actions/checkout@v3
+
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
@@ -55,6 +57,8 @@ jobs:
         working-directory: ./cdp-langchain
 
     steps:
+      - uses: actions/checkout@v3
+
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
- API Docs generation GHA: Add step to checkout repo