### PR TITLE
feat: Export Agentic Wallet Default Address ID

### DIFF
--- a/cdp-langchain/cdp_langchain/utils/cdp_agentkit_wrapper.py
+++ b/cdp-langchain/cdp_langchain/utils/cdp_agentkit_wrapper.py
@@ -69,6 +69,9 @@ class CdpAgentkitWrapper(BaseModel):
 
         """
         wallet_data_dict = self.wallet.export_data().to_dict()
+
+        wallet_data_dict["default_address_id"] = self.wallet.default_address.address_id
+
         return json.dumps(wallet_data_dict)
 
     def uniswap_v3_create_pool_wrapper(self, token_a: str, token_b: str, fee: str) -> str:


### PR DESCRIPTION
- Export agent's wallet default address ID as `default_address_id` on wallet data.