### PR TITLE
fix: Remove README Release Widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # CDP Agentkit
 
-[![Release Notes](https://img.shields.io/github/release/coinbase/cdp-agentkit?style=flat-square)](https://github.com/coinbase/cdp-agentkit/releases)
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/cdp-agentkit-core?style=flat-square)](https://pypistats.org/packages/cdp-agentkit-core)
 [![GitHub star chart](https://img.shields.io/github/stars/coinbase/cdp-agentkit?style=flat-square)](https://star-history.com/#coinbase/cdp-agentkit)
 [![Open Issues](https://img.shields.io/github/issues-raw/coinbase/cdp-agentkit?style=flat-square)](https://github.com/coinbase/cdp-agentkit/issues)


### PR DESCRIPTION
- This widget is unused since we will not be using GH releases for the corresponding PyPI releases 