### PR TITLE
chore: Bump version to 0.0.2

### DIFF
--- a/cdp-agentkit-core/CHANGELOG.md
+++ b/cdp-agentkit-core/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## Unreleased
 
+## [0.0.2] - 2024-11-07
+
 ### Added
 
 - Added `wow_create_token` action.
+- Enhanced prompts.
+- Refactored Action exports.
 
 ## [0.0.1] - 2024-11-04
 

--- a/cdp-agentkit-core/docs/conf.py
+++ b/cdp-agentkit-core/docs/conf.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.abspath(".."))
 
 project = 'CDP Agentkit - Core'
 author = 'Coinbase Developer Platform'
-release = '0.0.1'
+release = '0.0.2'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/cdp-agentkit-core/pyproject.toml
+++ b/cdp-agentkit-core/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cdp-agentkit-core"
-version = "0.0.1"
+version = "0.0.2"
 description = "CDP Agentkit core primitives"
 authors = ["John Peterson <john.peterson@coinbase.com>"]
 readme = "README.md"

--- a/cdp-langchain/CHANGELOG.md
+++ b/cdp-langchain/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## Unreleased
 
+## [0.0.2] - 2024-11-07
+
 ### Added
 
 - Added `wow_create_token` action to the cdp toolkit.
+- Refactor most action/tool implementation to `cdp-agentkit-core`.
 
 ## [0.0.1] - 2024-11-04
 

--- a/cdp-langchain/docs/conf.py
+++ b/cdp-langchain/docs/conf.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.abspath(".."))
 
 project = 'CDP Agentkit - LangChain'
 author = 'Coinbase Developer Platform'
-release = '0.0.1'
+release = '0.0.2'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/cdp-langchain/poetry.lock
+++ b/cdp-langchain/poetry.lock
@@ -480,7 +480,7 @@ test = ["coverage (>=7)", "hypothesis", "pytest"]
 
 [[package]]
 name = "cdp-agentkit-core"
-version = "0.0.1"
+version = "0.0.2"
 description = "CDP Agentkit core primitives"
 optional = false
 python-versions = "^3.10"
@@ -4303,4 +4303,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "8eb6f9fef68b8d7d81949f2da054f236334a592e4875a9aa23ac87d5b0154aee"
+content-hash = "88f219e745897ed493035d9040d262a7761cd044cb6881447a27affeb2525302"

--- a/cdp-langchain/pyproject.toml
+++ b/cdp-langchain/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cdp-langchain"
-version = "0.0.1"
+version = "0.0.2"
 description = "CDP Agentkit Langchain Extension"
 authors = ["John Peterson <john.peterson@coinbase.com>"]
 readme = "README.md"
@@ -15,7 +15,7 @@ langchain-openai = "^0.2.4"
 langgraph = "^0.2.39"
 cdp-sdk = "^0.10.3"
 pydantic = "^2.0"
-cdp-agentkit-core = "^0.0.1"
+cdp-agentkit-core = "^0.0.2"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.7.1"


### PR DESCRIPTION
### What changed? Why?
- release `0.0.2` of `cdp-langchain` and `cdp-agentkit-core`

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
