### PR TITLE
Twitter langchain release 0.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,3 @@ See [Twitter Langchain](./twitter-langchain/README.md) to get started!
 CDP Agentkit welcomes community contributions.
 See [CONTRIBUTING.md](CONTRIBUTING.md) for more information.
 
-## Contributors
-<a href="https://github.com/coinbase/cdp-agentkit/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=coinbase/cdp-agentkit" />
-</a>
-

--- a/twitter-langchain/README.md
+++ b/twitter-langchain/README.md
@@ -106,6 +106,4 @@ See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed setup instructions and co
 
 ## Documentation
 For detailed documentation, please visit:
-- [Agentkit-Core](https://coinbase.github.io/cdp-agentkit-core)
-- [Agentkit-Langchain](https://coinbase.github.io/cdp-langchain)
-- [Agentkit-Twitter-Langchain](https://coinbase.github.io/twitter-langchain)
+- [Agentkit-Core](https://coinbase.github.io/cdp-agentkit/cdp-agentkit-core/)

--- a/twitter-langchain/poetry.lock
+++ b/twitter-langchain/poetry.lock
@@ -3022,6 +3022,17 @@ pymysql = ["pymysql"]
 sqlcipher = ["sqlcipher3_binary"]
 
 [[package]]
+name = "standard-imghdr"
+version = "3.13.0"
+description = "Standard library imghdr redistribution. \"dead battery\"."
+optional = false
+python-versions = "*"
+files = [
+    {file = "standard_imghdr-3.13.0-py3-none-any.whl", hash = "sha256:30a1bff5465605bb496f842a6ac3cc1f2131bf3025b0da28d4877d6d4b7cc8e9"},
+    {file = "standard_imghdr-3.13.0.tar.gz", hash = "sha256:8d9c68058d882f6fc3542a8d39ef9ff94d2187dc90bd0c851e0902776b7b7a42"},
+]
+
+[[package]]
 name = "tenacity"
 version = "9.0.0"
 description = "Retry code until it succeeds"
@@ -3445,4 +3456,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "40309897ad0a28344cdf46901affb829cb57fcf6ed1fee18ec2ef67e1adc5131"
+content-hash = "ff63139f921aa819b00d87669adc60682d4d9c1ed14383ffbfd3a230429f249a"

--- a/twitter-langchain/poetry.lock
+++ b/twitter-langchain/poetry.lock
@@ -455,7 +455,7 @@ test = ["coverage (>=7)", "hypothesis", "pytest"]
 
 [[package]]
 name = "cdp-agentkit-core"
-version = "0.0.1"
+version = "0.0.2"
 description = "CDP Agentkit core primitives"
 optional = false
 python-versions = "^3.10"
@@ -463,7 +463,7 @@ files = []
 develop = true
 
 [package.dependencies]
-cdp-sdk = "^0.10.1"
+cdp-sdk = "^0.10.3"
 pydantic = "^2.0"
 web3 = "7.2.0"
 
@@ -473,13 +473,13 @@ url = "../cdp-agentkit-core"
 
 [[package]]
 name = "cdp-sdk"
-version = "0.10.1"
+version = "0.10.3"
 description = "CDP Python SDK"
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "cdp_sdk-0.10.1-py3-none-any.whl", hash = "sha256:201306c8513592057dc0573d06edc6dfe010bdb4c8a76c185258993d66681afe"},
-    {file = "cdp_sdk-0.10.1.tar.gz", hash = "sha256:60a5967c0971e1c4e24d8716c33e4191db45cb601e2c148b36e32f19c8d3611f"},
+    {file = "cdp_sdk-0.10.3-py3-none-any.whl", hash = "sha256:b66fc2db340ab8e841cc49016b92b716d7da01f3e5b11cc160dabeb2f6cd501b"},
+    {file = "cdp_sdk-0.10.3.tar.gz", hash = "sha256:d637aa8ed4f6bee7f12b74b7afe5580247bc86c577738e9842f11add414daf7b"},
 ]
 
 [package.dependencies]
@@ -1774,13 +1774,13 @@ langchain-core = ">=0.3.15,<0.4.0"
 
 [[package]]
 name = "langsmith"
-version = "0.1.140"
+version = "0.1.141"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 optional = false
 python-versions = "<4.0,>=3.8.1"
 files = [
-    {file = "langsmith-0.1.140-py3-none-any.whl", hash = "sha256:3de70183ae19a4ada4d77a8a9f336ff95ca0ead98215771033ee889a2889fe19"},
-    {file = "langsmith-0.1.140.tar.gz", hash = "sha256:cb0a717d7b9e6d3145285d7ca0ab216e064cbe7a1ca4139fc04af57fb2315e70"},
+    {file = "langsmith-0.1.141-py3-none-any.whl", hash = "sha256:e133c6bed9c6d274f19735696a169dea890d35d444ae61c25fb47082aa2d0f16"},
+    {file = "langsmith-0.1.141.tar.gz", hash = "sha256:f3f17d2abc7b8a3857ad8d492b535970109b5ea40e712df91a782522ed581516"},
 ]
 
 [package.dependencies]
@@ -2106,13 +2106,13 @@ files = [
 
 [[package]]
 name = "packaging"
-version = "24.1"
+version = "24.2"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "packaging-24.1-py3-none-any.whl", hash = "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"},
-    {file = "packaging-24.1.tar.gz", hash = "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002"},
+    {file = "packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"},
+    {file = "packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"},
 ]
 
 [[package]]
@@ -2858,29 +2858,29 @@ test = ["hypothesis (==5.19.0)", "pytest (>=7.0.0)", "pytest-xdist (>=2.4.0)"]
 
 [[package]]
 name = "ruff"
-version = "0.7.2"
+version = "0.7.3"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "ruff-0.7.2-py3-none-linux_armv6l.whl", hash = "sha256:b73f873b5f52092e63ed540adefc3c36f1f803790ecf2590e1df8bf0a9f72cb8"},
-    {file = "ruff-0.7.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:5b813ef26db1015953daf476202585512afd6a6862a02cde63f3bafb53d0b2d4"},
-    {file = "ruff-0.7.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:853277dbd9675810c6826dad7a428d52a11760744508340e66bf46f8be9701d9"},
-    {file = "ruff-0.7.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:21aae53ab1490a52bf4e3bf520c10ce120987b047c494cacf4edad0ba0888da2"},
-    {file = "ruff-0.7.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ccc7e0fc6e0cb3168443eeadb6445285abaae75142ee22b2b72c27d790ab60ba"},
-    {file = "ruff-0.7.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fd77877a4e43b3a98e5ef4715ba3862105e299af0c48942cc6d51ba3d97dc859"},
-    {file = "ruff-0.7.2-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:e00163fb897d35523c70d71a46fbaa43bf7bf9af0f4534c53ea5b96b2e03397b"},
-    {file = "ruff-0.7.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f3c54b538633482dc342e9b634d91168fe8cc56b30a4b4f99287f4e339103e88"},
-    {file = "ruff-0.7.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7b792468e9804a204be221b14257566669d1db5c00d6bb335996e5cd7004ba80"},
-    {file = "ruff-0.7.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dba53ed84ac19ae4bfb4ea4bf0172550a2285fa27fbb13e3746f04c80f7fa088"},
-    {file = "ruff-0.7.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:b19fafe261bf741bca2764c14cbb4ee1819b67adb63ebc2db6401dcd652e3748"},
-    {file = "ruff-0.7.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28bd8220f4d8f79d590db9e2f6a0674f75ddbc3847277dd44ac1f8d30684b828"},
-    {file = "ruff-0.7.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9fd67094e77efbea932e62b5d2483006154794040abb3a5072e659096415ae1e"},
-    {file = "ruff-0.7.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:576305393998b7bd6c46018f8104ea3a9cb3fa7908c21d8580e3274a3b04b691"},
-    {file = "ruff-0.7.2-py3-none-win32.whl", hash = "sha256:fa993cfc9f0ff11187e82de874dfc3611df80852540331bc85c75809c93253a8"},
-    {file = "ruff-0.7.2-py3-none-win_amd64.whl", hash = "sha256:dd8800cbe0254e06b8fec585e97554047fb82c894973f7ff18558eee33d1cb88"},
-    {file = "ruff-0.7.2-py3-none-win_arm64.whl", hash = "sha256:bb8368cd45bba3f57bb29cbb8d64b4a33f8415d0149d2655c5c8539452ce7760"},
-    {file = "ruff-0.7.2.tar.gz", hash = "sha256:2b14e77293380e475b4e3a7a368e14549288ed2931fce259a6f99978669e844f"},
+    {file = "ruff-0.7.3-py3-none-linux_armv6l.whl", hash = "sha256:34f2339dc22687ec7e7002792d1f50712bf84a13d5152e75712ac08be565d344"},
+    {file = "ruff-0.7.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fb397332a1879b9764a3455a0bb1087bda876c2db8aca3a3cbb67b3dbce8cda0"},
+    {file = "ruff-0.7.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:37d0b619546103274e7f62643d14e1adcbccb242efda4e4bdb9544d7764782e9"},
+    {file = "ruff-0.7.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d59f0c3ee4d1a6787614e7135b72e21024875266101142a09a61439cb6e38a5"},
+    {file = "ruff-0.7.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:44eb93c2499a169d49fafd07bc62ac89b1bc800b197e50ff4633aed212569299"},
+    {file = "ruff-0.7.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6d0242ce53f3a576c35ee32d907475a8d569944c0407f91d207c8af5be5dae4e"},
+    {file = "ruff-0.7.3-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:6b6224af8b5e09772c2ecb8dc9f3f344c1aa48201c7f07e7315367f6dd90ac29"},
+    {file = "ruff-0.7.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c50f95a82b94421c964fae4c27c0242890a20fe67d203d127e84fbb8013855f5"},
+    {file = "ruff-0.7.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7f3eff9961b5d2644bcf1616c606e93baa2d6b349e8aa8b035f654df252c8c67"},
+    {file = "ruff-0.7.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8963cab06d130c4df2fd52c84e9f10d297826d2e8169ae0c798b6221be1d1d2"},
+    {file = "ruff-0.7.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:61b46049d6edc0e4317fb14b33bd693245281a3007288b68a3f5b74a22a0746d"},
+    {file = "ruff-0.7.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:10ebce7696afe4644e8c1a23b3cf8c0f2193a310c18387c06e583ae9ef284de2"},
+    {file = "ruff-0.7.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:3f36d56326b3aef8eeee150b700e519880d1aab92f471eefdef656fd57492aa2"},
+    {file = "ruff-0.7.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5d024301109a0007b78d57ab0ba190087b43dce852e552734ebf0b0b85e4fb16"},
+    {file = "ruff-0.7.3-py3-none-win32.whl", hash = "sha256:4ba81a5f0c5478aa61674c5a2194de8b02652f17addf8dfc40c8937e6e7d79fc"},
+    {file = "ruff-0.7.3-py3-none-win_amd64.whl", hash = "sha256:588a9ff2fecf01025ed065fe28809cd5a53b43505f48b69a1ac7707b1b7e4088"},
+    {file = "ruff-0.7.3-py3-none-win_arm64.whl", hash = "sha256:1713e2c5545863cdbfe2cbce21f69ffaf37b813bfd1fb3b90dc9a6f1963f5a8c"},
+    {file = "ruff-0.7.3.tar.gz", hash = "sha256:e1d1ba2e40b6e71a61b063354d04be669ab0d39c352461f3d789cac68b54a313"},
 ]
 
 [[package]]
@@ -3445,4 +3445,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "2c23887b15bdc56deed14a68ad310b61c1f05d3d7cd8e3a8cb0918f3a43a7f6c"
+content-hash = "40309897ad0a28344cdf46901affb829cb57fcf6ed1fee18ec2ef67e1adc5131"

--- a/twitter-langchain/pyproject.toml
+++ b/twitter-langchain/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "twitter-langchain"
-version = "0.0.1"
+version = "0.0.2"
 description = "Twitter Langchain Toolkit"
 authors = ["John Peterson <john.peterson@coinbase.com>"]
 license = "Apache-2.0"
@@ -12,6 +12,7 @@ pydantic = "^2.9.2"
 langchain = "^0.3.7"
 tweepy = "^4.14.0"
 cdp-agentkit-core = "^0.0.2"
+standard-imghdr = "^3.13.0"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.7.2"

--- a/twitter-langchain/pyproject.toml
+++ b/twitter-langchain/pyproject.toml
@@ -11,7 +11,7 @@ python = "^3.10"
 pydantic = "^2.9.2"
 langchain = "^0.3.7"
 tweepy = "^4.14.0"
-cdp-agentkit-core = "^0.0.1"
+cdp-agentkit-core = "^0.0.2"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.7.2"


### PR DESCRIPTION
### What changed? Why?
- Clean up READMEs
- Release `twitter-langchain` - `0.0.2`
- Bump dep on `cdp-agentkit-core` to `0.0.2`
- Add `standard-imghdr` as a dep - this package was in the Python standard lib until `3.13` so this dep patches broken behavior in `>=3.13`


#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
