### PR TITLE
feat: Chatbot Example Use CDP Config File

### DIFF
--- a/cdp-langchain/examples/chatbot/README.md
+++ b/cdp-langchain/examples/chatbot/README.md
@@ -30,10 +30,9 @@ pip install cdp-langchain
 
 ### Set ENV Vars
 - Ensure the following ENV Vars are set:
-  - "CDP_API_KEY_NAME"
-  - "CDP_API_KEY_PRIVATE_KEY"
   - "OPENAI_API_KEY"
   - "NETWORK_ID" (Defaults to `base-sepolia`)
+- Update `./cdp_config.json` with your CDP API Key name and private key
 
 ```bash
 python chatbot.py

--- a/cdp-langchain/examples/chatbot/cdp_config.json
+++ b/cdp-langchain/examples/chatbot/cdp_config.json
@@ -1,0 +1,4 @@
+{
+  "cdp_api_key_name": "paste-your-cdp-api-key-name-here",
+  "cdp_api_key_private_key": "paste-your-cdp-api-key-private-key-here"
+}

--- a/cdp-langchain/examples/chatbot/chatbot.py
+++ b/cdp-langchain/examples/chatbot/chatbot.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sys
 import time
@@ -13,6 +14,9 @@ from cdp_langchain.utils import CdpAgentkitWrapper
 
 # Configure a file to persist the agent's CDP MPC Wallet Data.
 wallet_data_file = "wallet_data.txt"
+
+# Configure a file to hold CDP config.
+cdp_config_file_path = "cdp_config.json"
 
 
 def initialize_agent():
@@ -31,6 +35,11 @@ def initialize_agent():
     if wallet_data is not None:
         # If there is a persisted agentic wallet, load it and pass to the CDP Agentkit Wrapper.
         values = {"cdp_wallet_data": wallet_data}
+
+    with open(os.path.expanduser(cdp_config_file_path)) as f:
+        cdp_config_data = json.load(f)
+        values["cdp_api_key_name"] = cdp_config_data.get("cdp_api_key_name")
+        values["cdp_api_key_private_key"] = cdp_config_data.get("cdp_api_key_private_key")
 
     agentkit = CdpAgentkitWrapper(**values)
 


### PR DESCRIPTION
### What changed? Why?
- ENV VAR parsing is causing issues due to the `\n` literals in the private key. It is better handled with JSON parsing
- Chatbot example is updated to use a `cdp_config.json` file where developers can paste their API key creds

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
