### PR TITLE
Typos CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ class MintNftInput(BaseModel):
     )
     destination: str = Field(
         ...,
-        description="The destination address that will receieve the NFT onchain, e.g. `0x036CbD53842c5426634e7929541eC2318f3dCF7e`",
+        description="The destination address that will receive the NFT onchain, e.g. `0x036CbD53842c5426634e7929541eC2318f3dCF7e`",
     )
 ```
 - `func` - A function (or Callable class) that executes the action.
@@ -69,7 +69,7 @@ def mint_nft(wallet: Wallet, contract_address: str, destination: str) -> str:
     Args:
         wallet (Wallet): The wallet to trade the asset from.
         contract_address (str): The contract address of the NFT (ERC-721) to mint, e.g. `0x036CbD53842c5426634e7929541eC2318f3dCF7e`.
-        destination (str): The destination address that will receieve the NFT onchain, e.g. `0x036CbD53842c5426634e7929541eC2318f3dCF7e`.
+        destination (str): The destination address that will receive the NFT onchain, e.g. `0x036CbD53842c5426634e7929541eC2318f3dCF7e`.
 
     Returns:
         str: A message containing the NFT mint details.


### PR DESCRIPTION
### What changed? Why?

This pull request corrects a common spelling error in two places within the documentation:

<img width="1009" alt="Снимок экрана 2024-11-12 в 20 13 01" src="https://github.com/user-attachments/assets/c6f8acce-8329-4fb2-99dd-fb088d24ac98">
<img width="1049" alt="Снимок экрана 2024-11-12 в 20 13 29" src="https://github.com/user-attachments/assets/af6a3cda-9420-452a-b7ec-78615ff07dd3">

The word "receieve" has been changed to "**receive**" to ensure consistency and proper spelling.

This is a minor fix but helps improve the clarity and professionalism of the documentation.

