### PR TITLE
Typos Update mint_nft.py

### DIFF
--- a/cdp-agentkit-core/cdp_agentkit_core/actions/mint_nft.py
+++ b/cdp-agentkit-core/cdp_agentkit_core/actions/mint_nft.py
@@ -18,7 +18,7 @@ class MintNftInput(BaseModel):
     )
     destination: str = Field(
         ...,
-        description="The destination address that will receieve the NFT onchain, e.g. `0x036CbD53842c5426634e7929541eC2318f3dCF7e`",
+        description="The destination address that will receive the NFT onchain, e.g. `0x036CbD53842c5426634e7929541eC2318f3dCF7e`",
     )
 
 
@@ -28,7 +28,7 @@ def mint_nft(wallet: Wallet, contract_address: str, destination: str) -> str:
     Args:
         wallet (Wallet): The wallet to trade the asset from.
         contract_address (str): The contract address of the NFT (ERC-721) to mint, e.g. `0x036CbD53842c5426634e7929541eC2318f3dCF7e`.
-        destination (str): The destination address that will receieve the NFT onchain, e.g. `0x036CbD53842c5426634e7929541eC2318f3dCF7e`.
+        destination (str): The destination address that will receive the NFT onchain, e.g. `0x036CbD53842c5426634e7929541eC2318f3dCF7e`.
 
     Returns:
         str: A message containing the NFT mint details.


### PR DESCRIPTION
### What changed? Why?

<img width="893" alt="Снимок экрана 2024-11-12 в 21 49 45" src="https://github.com/user-attachments/assets/d67f900f-5302-4a54-9d26-b41dbf130c13">

The word "receieve" has been changed to "receive" to ensure consistency and proper spelling.