### PR TITLE
Add ability to pass in custom metadata for wow token creation

### DIFF
--- a/cdp-agentkit-core/CHANGELOG.md
+++ b/cdp-agentkit-core/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Added `wow_buy_token` and `wow_sell_token`.
+- Added `token_uri` to `wow_create_token` action for custom token metadata.
 
 ## [0.0.3] - 2024-11-09
 

--- a/cdp-agentkit-core/cdp_agentkit_core/actions/wow/create_token.py
+++ b/cdp-agentkit-core/cdp_agentkit_core/actions/wow/create_token.py
@@ -11,7 +11,7 @@ from cdp_agentkit_core.actions.wow.constants import (
 )
 
 WOW_CREATE_TOKEN_PROMPT = """
-This tool will create a Zora Wow ERC20 memecoin using the WoW factory. This tool takes the token name and token symbol. It uses a bonding curve so there is no need to add liquidity to the pool upfront. It is only supported on Base Sepolia and Base Mainnet.
+This tool will create a Zora Wow ERC20 memecoin using the WoW factory. This tool takes the token name, token symbol, and optionally a token URI containing metadata about the token. It uses a bonding curve so there is no need to add liquidity to the pool upfront. It is only supported on Base Sepolia and Base Mainnet.
 """
 
 
@@ -26,15 +26,20 @@ class WowCreateTokenInput(BaseModel):
         ...,
         description="The symbol of the token to create, e.g. WOW",
     )
+    token_uri: str = Field(
+        default=None,
+        description="The URI of the token metadata to store on IPFS, e.g. ipfs://QmY1GqprFYvojCcUEKgqHeDj9uhZD9jmYGrQTfA9vAE78J",
+    )
 
 
-def wow_create_token(wallet: Wallet, name: str, symbol: str) -> str:
+def wow_create_token(wallet: Wallet, name: str, symbol: str, token_uri: str | None = None) -> str:
     """Create a Zora Wow ERC20 memecoin.
 
     Args:
         wallet (Wallet): The wallet to create the token from.
         name (str): The name of the token to create.
         symbol (str): The symbol of the token to create.
+        token_uri (str | None): The URI of the token metadata to store on IPFS e.g. ipfs://QmY1GqprFYvojCcUEKgqHeDj9uhZD9jmYGrQTfA9vAE78J.
 
     Returns:
         str: A message containing the token creation details.
@@ -50,7 +55,7 @@ def wow_create_token(wallet: Wallet, name: str, symbol: str) -> str:
             args={
                 "_tokenCreator": wallet.default_address.address_id,
                 "_platformReferrer": "0x0000000000000000000000000000000000000000",
-                "_tokenURI": GENERIC_TOKEN_METADATA_URI,
+                "_tokenURI": token_uri or GENERIC_TOKEN_METADATA_URI,
                 "_name": name,
                 "_symbol": symbol,
             },

--- a/cdp-agentkit-core/tests/actions/wow/test_create_token.py
+++ b/cdp-agentkit-core/tests/actions/wow/test_create_token.py
@@ -16,6 +16,7 @@ MOCK_NAME = "Test Token"
 MOCK_SYMBOL = "TEST"
 MOCK_NETWORK_ID = "base-sepolia"
 MOCK_WALLET_ADDRESS = "0x1234567890123456789012345678901234567890"
+MOCK_TOKEN_URI = "ipfs://QmY1GqprFYvojCcUEKgqHeDj9uhZD9jmYGrQTfA9vAE78J"
 
 
 def test_create_token_input_model_valid():
@@ -23,6 +24,7 @@ def test_create_token_input_model_valid():
     input_model = WowCreateTokenInput(
         name=MOCK_NAME,
         symbol=MOCK_SYMBOL,
+        token_uri=MOCK_TOKEN_URI,
     )
 
     assert input_model.name == MOCK_NAME
@@ -104,3 +106,45 @@ def test_create_token_api_error(wallet_factory):
                 "_symbol": MOCK_SYMBOL,
             },
         )
+
+
+def test_create_token_with_custom_token_uri_success(wallet_factory, contract_invocation_factory):
+    """Test successful token creation with valid parameters."""
+    mock_wallet = wallet_factory()
+    mock_contract_instance = contract_invocation_factory()
+    mock_wallet.default_address.address_id = MOCK_WALLET_ADDRESS
+    mock_wallet.network_id = MOCK_NETWORK_ID
+
+    mock_token_uri = "ipfs://QmWJ2tJB8jUHwhB2MtFb7Ew242bNKiw59A3fZQqxqtShkD"
+
+    with (
+        patch.object(
+            mock_wallet, "invoke_contract", return_value=mock_contract_instance
+        ) as mock_invoke,
+        patch.object(
+            mock_contract_instance, "wait", return_value=mock_contract_instance
+        ) as mock_contract_wait,
+    ):
+        action_response = wow_create_token(
+            mock_wallet,
+            MOCK_NAME,
+            MOCK_SYMBOL,
+            token_uri=mock_token_uri,
+        )
+
+        expected_response = f"Created WoW ERC20 memecoin {MOCK_NAME} with symbol {MOCK_SYMBOL} on network {MOCK_NETWORK_ID}.\nTransaction hash for the token creation: {mock_contract_instance.transaction.transaction_hash}\nTransaction link for the token creation: {mock_contract_instance.transaction.transaction_link}"
+        assert action_response == expected_response
+
+        mock_invoke.assert_called_once_with(
+            contract_address=get_factory_address(MOCK_NETWORK_ID),
+            method="deploy",
+            abi=WOW_FACTORY_ABI,
+            args={
+                "_tokenCreator": MOCK_WALLET_ADDRESS,
+                "_platformReferrer": "0x0000000000000000000000000000000000000000",
+                "_tokenURI": mock_token_uri,
+                "_name": MOCK_NAME,
+                "_symbol": MOCK_SYMBOL,
+            },
+        )
+        mock_contract_wait.assert_called_once_with()


### PR DESCRIPTION
### What changed? Why?
Currently all tokens created on wow through this tool have the same token metadata, allow passing custom metadata so people can override things like token image

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
works case it'd break the tool, seems unlikely