### PR TITLE
Add API reference to README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for more information.
 - [CDP Agentkit Documentation](https://docs.cdp.coinbase.com/agentkit/docs/welcome)
 - [CDP Agentkit Core API Reference](https://coinbase.github.io/cdp-agentkit/cdp-agentkit-core/index.html)
 - [CDP Agentkit Langchain Extension API Reference](https://coinbase.github.io/cdp-agentkit/cdp-langchain/index.html)
+- [Twitter Langchain API Reference](https://coinbase.github.io/cdp-agentkit/twitter-langchain/index.html)

--- a/cdp-agentkit-core/README.md
+++ b/cdp-agentkit-core/README.md
@@ -3,5 +3,8 @@ Framework agnostic primitives that are meant to be composable and used via Agent
 
 You can find all of the supported actions under `./cdp_agentkit_core/actions`
 
+## API Reference
+For detailed API documentation, please visit the [CDP Agentkit Core API Reference](https://coinbase.github.io/cdp-agentkit/cdp-agentkit-core/index.html).
+
 ## Contributing
 See [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

--- a/cdp-langchain/README.md
+++ b/cdp-langchain/README.md
@@ -112,5 +112,8 @@ The following operations support gasless transactions on Base Mainnet:
 - EURC transfers
 - cbBTC transfers
 
+## API Reference
+For detailed API documentation, please visit the [CDP Agentkit Langchain Extension API Reference](https://coinbase.github.io/cdp-agentkit/cdp-langchain/index.html).
+
 ## Contributing
 See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed setup instructions and contribution guidelines.

--- a/twitter-langchain/README.md
+++ b/twitter-langchain/README.md
@@ -107,3 +107,6 @@ See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed setup instructions and co
 ## Documentation
 For detailed documentation, please visit:
 - [Agentkit-Core](https://coinbase.github.io/cdp-agentkit/cdp-agentkit-core/)
+
+## API Reference
+For detailed API documentation, please visit the [Twitter Langchain API Reference](https://coinbase.github.io/cdp-agentkit/twitter-langchain/index.html).


### PR DESCRIPTION
Add API reference sections to README files.

* **cdp-agentkit-core/README.md**
  - Add a section for the API reference with a link to the generated documentation.
* **cdp-langchain/README.md**
  - Add a section for the API reference with a link to the generated documentation.
* **twitter-langchain/README.md**
  - Add a section for the API reference with a link to the generated documentation.
* **README.md**
  - Add a section for the API reference with links to the generated documentation for each package.

