### PR TITLE
chore: Use Poetry venv for make test

### DIFF
--- a/cdp-agentkit-core/Makefile
+++ b/cdp-agentkit-core/Makefile
@@ -20,4 +20,4 @@ local-docs: docs
 
 .PHONY: test
 test:
-	pytest
+	poetry run pytest

--- a/cdp-langchain/Makefile
+++ b/cdp-langchain/Makefile
@@ -20,4 +20,4 @@ local-docs: docs
 
 .PHONY: test
 test:
-	pytest
+	poetry run pytest


### PR DESCRIPTION
### What changed? Why?
- Use `poetry` virtual env to run `pytest` in `make test`

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
